### PR TITLE
Version 0.6.2

### DIFF
--- a/backend/src/time_utilities/breakEnd.js
+++ b/backend/src/time_utilities/breakEnd.js
@@ -14,7 +14,7 @@ exports.breakEnd = async (req, res) => {
   );
 
   if (response.rows.length == 0) {
-    return res.status(400).json({
+    return res.status(400).clearCookie("access_token", { httpOnly: true }).json({
       errors: [
         {
           type: "field",
@@ -39,7 +39,7 @@ exports.breakEnd = async (req, res) => {
   );
 
   if (!response.rows[0].break_start_timestamp) {
-    return res.status(400).json({
+    return res.status(400).clearCookie("access_token", { httpOnly: true }).json({
       errors: [
         {
           type: "field",
@@ -53,7 +53,7 @@ exports.breakEnd = async (req, res) => {
   }
 
   if (response.rows[0].break_end_timestamp) {
-    return res.status(400).json({
+    return res.status(400).clearCookie("access_token", { httpOnly: true }).json({
       errors: [
         {
           type: "field",
@@ -82,18 +82,19 @@ exports.breakEnd = async (req, res) => {
 
     await client.query("COMMIT");
 
-    return res.status(200).json({
+    return res.status(200).clearCookie("access_token", { httpOnly: true }).json({
       success: true,
       message: `Break ended!`,
-      signed_in: true,
+      signed_in: false,
       clocked_in: true,
       on_break: false,
+      had_break: true,
     });
   } catch (error) {
     console.log(error);
     await client.query("ROLLBACK");
 
-    return res.status(500).json({
+    return res.status(500).clearCookie("access_token", { httpOnly: true }).json({
       errors: [
         {
           type: "Unknown",

--- a/backend/src/time_utilities/breakStart.js
+++ b/backend/src/time_utilities/breakStart.js
@@ -14,7 +14,7 @@ exports.breakStart = async (req, res) => {
   );
 
   if (response.rows.length == 0) {
-    return res.status(400).json({
+    return res.status(400).clearCookie("access_token", { httpOnly: true }).json({
       errors: [
         {
           type: "field",
@@ -39,7 +39,7 @@ exports.breakStart = async (req, res) => {
   );
 
   if (response.rows[0].break_start_timestamp) {
-    return res.status(400).json({
+    return res.status(400).clearCookie("access_token", { httpOnly: true }).json({
       errors: [
         {
           type: "field",
@@ -68,18 +68,19 @@ exports.breakStart = async (req, res) => {
 
     await client.query("COMMIT");
 
-    return res.status(200).json({
+    return res.status(200).clearCookie("access_token", { httpOnly: true }).json({
       success: true,
       message: `Break started!`,
-      signed_in: true,
+      signed_in: false,
       clocked_in: true,
       on_break: true,
+      had_break: false,
     });
   } catch (error) {
     console.log(error);
     await client.query("ROLLBACK");
 
-    return res.status(500).json({
+    return res.status(500).clearCookie("access_token", { httpOnly: true }).json({
       errors: [
         {
           type: "Unknown",

--- a/backend/src/time_utilities/clockOut.js
+++ b/backend/src/time_utilities/clockOut.js
@@ -14,7 +14,7 @@ exports.clockOut = async (req, res) => {
   );
 
   if (response.rows.length == 0) {
-    return res.status(400).json({
+    return res.status(400).clearCookie("access_token", { httpOnly: true }).json({
       errors: [
         {
           type: "field",
@@ -39,7 +39,7 @@ exports.clockOut = async (req, res) => {
     );
 
     if (response.rows[0].break_start_timestamp && !response.rows[0].break_end_timestamp) {
-      return res.status(400).json({
+      return res.status(400).clearCookie("access_token", { httpOnly: true }).json({
         errors: [
           {
             type: "field",
@@ -84,12 +84,13 @@ exports.clockOut = async (req, res) => {
       signed_in: false,
       clocked_in: false,
       on_break: false,
+      had_break: true,
     });
   } catch (error) {
     console.log(error);
     await client.query("ROLLBACK");
 
-    return res.status(500).json({
+    return res.status(500).clearCookie("access_token", { httpOnly: true }).json({
       errors: [
         {
           type: "Unknown",


### PR DESCRIPTION
Fixes a bug in the CheckEmplyoeePin route which fails to check if the employee ID entered exists in the database.

Time routes now return a Boolean value to represent whether or not an employee already took/started a break to make it easier for the frontend to render the appropriate options to users.

Now, the clock out and break start/end routes clear the access token cookie to make sure that employees are forced to sign in after every action on the time system. Note that this occurs even in error cases.