### PR TITLE
Fix code scanning alert no. 3: Missing CSRF middleware

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -26,7 +26,8 @@
     "nodemon": "^3.1.4",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
-    "pg": "^8.12.0"
+    "pg": "^8.12.0",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -2,6 +2,7 @@ const express = require("express");
 const app = express();
 const { NODE_ENV, SERVER_PORT, CLIENT_URL, CLIENT_PORT } = require("./constants");
 const cookieParser = require("cookie-parser");
+const lusca = require("lusca");
 const passport = require("passport");
 const cors = require("cors");
 const path = require("path");
@@ -21,6 +22,7 @@ app.use(express.json());
 app.use(cookieParser());
 app.use(cors({ origin: clientUrlString, credentials: true }));
 app.use(passport.initialize());
+app.use(lusca.csrf());
 app.use(limiter);
 
 //import routes


### PR DESCRIPTION
Fixes [https://github.com/AlanTuecci/BMS-Suite/security/code-scanning/3](https://github.com/AlanTuecci/BMS-Suite/security/code-scanning/3)

To fix the problem, we need to add CSRF protection middleware to the Express application. The `lusca` package provides a CSRF middleware that can be easily integrated. We will install the `lusca` package and then use its CSRF middleware in the application.

1. Install the `lusca` package.
2. Import the `lusca` package in the `backend/src/index.js` file.
3. Add the `lusca.csrf()` middleware to the Express application after the `cookieParser` middleware.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
